### PR TITLE
Add exportGcode method for Klipper Users (non-WebSerial printing) 

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -110,6 +110,7 @@
         <div class="menu-item" onclick="evaluateJs('_fab.serial.requestPort();')">connect</div>
         <div class="menu-item" onclick="evaluateJs('_fab.print();')">start print</div>
         <div class="menu-item" onclick="evaluateJs('_fab.stopPrint();')">stop print</div>
+        <div class="menu-item" onclick="evaluateJs('_fab.exportGcode();')">export gcode</div>
         <a href="https://github.com/machineagency/p5.fab" target="_blank" rel="noopener noreferrer"
           id="top-bar-link">source</a>
         <div class="menu-item" onclick="showInfoModal()">info</div>

--- a/examples/2.5D-sketching/sketch.js
+++ b/examples/2.5D-sketching/sketch.js
@@ -21,6 +21,12 @@ function setup() {
     stopButton.mousePressed(function() {
       fab.stopPrint(); // stop streaming the commands to printer
     });
+
+    let exportButton = createButton('export!');
+    exportButton.position(20, 140);
+    exportButton.mousePressed(function() {
+      fab.exportGcode(); // export gcode to a file.
+    });
 }
 
 function fabDraw() {
@@ -55,6 +61,7 @@ function fabDraw() {
     r -= 0.1; 
   }
   fab.presentPart();
+  //console.log(fab.commands);
 }
 
 function draw() {
@@ -62,3 +69,4 @@ function draw() {
   background(255);
   fab.render();
 }
+

--- a/examples/hollow-cube/sketch.js
+++ b/examples/hollow-cube/sketch.js
@@ -21,6 +21,12 @@ function setup() {
     stopButton.mousePressed(function() {
       fab.stopPrint(); // stop streaming the commands to printer
     });
+
+    let exportButton = createButton('export!');
+    exportButton.position(20, 140);
+    exportButton.mousePressed(function() {
+      fab.exportGcode(); // export gcode to a file.
+    });
 }
 
 function fabDraw() {

--- a/examples/line-vase/sketch.js
+++ b/examples/line-vase/sketch.js
@@ -22,6 +22,13 @@ function setup() {
     stopButton.mousePressed(function() {
       fab.stopPrint(); // stop streaming the commands to printer
     });
+
+  let exportButton = createButton('export!');
+    exportButton.position(20, 140);
+    exportButton.mousePressed(function() {
+      fab.exportGcode(); // export gcode to a file.
+    });
+
 }
 
 

--- a/examples/template/sketch.js
+++ b/examples/template/sketch.js
@@ -22,6 +22,12 @@ function setup() {
       fab.stopPrint(); // stop streaming the commands to printer.
     });
 
+    let exportButton = createButton('export!');
+    exportButton.position(20, 140);
+    exportButton.mousePressed(function() {
+      fab.exportGcode(); // export gcode to a file.
+    });
+
 }
 
 

--- a/examples/vase/sketch.js
+++ b/examples/vase/sketch.js
@@ -6,16 +6,28 @@ function setup() {
   fab = createFab();
 
   // add a buttons to connect to the printer & to print!
-  connectButton = createButton('connect!');
+  let connectButton = createButton('connect!');
   connectButton.position(20, 20);
   connectButton.mousePressed(function() {
     fab.serial.requestPort();
   });
 
-  printButton = createButton('print!');
+  let printButton = createButton('print!');
   printButton.position(20, 60);
   printButton.mousePressed(function() {
     fab.print();
+  });
+
+  let stopButton = createButton('stop!');
+  stopButton.position(20, 100);
+  stopButton.mousePressed(function() {
+    fab.stopPrint(); // stop streaming the commands to printer.
+  });
+
+  let exportButton = createButton('export!');
+  exportButton.position(20, 140);
+  exportButton.mousePressed(function() {
+    fab.exportGcode(); // export gcode to a file.
   });
 }
 

--- a/lib/p5.fab.js
+++ b/lib/p5.fab.js
@@ -425,6 +425,8 @@ class Fab {
         this.commandStream.unshift(cmd);
     }
 
+ 
+
     stopPrint() {
         this.commandStream = []; // clear commands
         this.isPrinting = false;
@@ -458,6 +460,20 @@ class Fab {
         this.add(retractCmd);
         var cmd = "G0 X0 Y180 F9000";
         this.add(cmd);
+    }
+
+    finishPrint() {
+        var finishCommands = [
+        "G1 Z79 F600 ; Move print head further up",
+        "G1 Z150 F600 ; Move print head further up",
+        "M140 S0 ; turn off heatbed",
+        "M104 S0 ; turn off temperature",
+        "M107 ; turn off fan",
+        "M84 X Y E ; disable motors"];
+
+        finishCommands.forEach(cmd => {
+            this.add(cmd);
+        });
     }
 
     waitCommand() {

--- a/lib/p5.fab.js
+++ b/lib/p5.fab.js
@@ -289,6 +289,22 @@ class Fab {
         });
     }
 
+    exportGcode(fileName = new Date().toISOString().slice(0, 19).replace(/:/g, "")) {
+        let gcodeText = "";
+        fab.commands.forEach(command => {
+          gcodeText += command + "\n";
+        });
+      
+        let element = document.createElement('a');
+        element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(gcodeText));
+        element.setAttribute('download', `${fileName}.gcode`);
+        element.style.display = 'none';
+        document.body.appendChild(element);
+        element.click();
+        document.body.removeChild(element);
+      
+      }
+
     render() {
         orbitControl(2, 2, 0.1);
 


### PR DESCRIPTION
Thank you for creating this amazing library.

In my specific use case, I'm running Klipper on a RaspberryPi, which prevents me from connecting a serial connection directly with my 3D printer. To work around this issue, I've added an exportGcode method which allows for the downloading of gcode files so it can be sent to the printer via Mainsail.

I've tested these changes in my local setup (Ender-3 Pro + Klipper + Mainsail) and confirmed that almost all of the provided sample files can be successfully printed. This addition should help other users who have a similar setup to mine.

