### PR TITLE
Fix Undefined Feed Rate in Gcode 

### DIFF
--- a/lib/p5.fab.js
+++ b/lib/p5.fab.js
@@ -971,7 +971,7 @@ class Fab {
     v = this.mm_sec_to_mm_min(v);
     this.v = parseFloat(v).toFixed(2);
     this.asyncPosition.e = e;
-    var cmd = `G0 X${this.asyncPosition.x} Y${this.asyncPosition.y} Z${this.asyncPosition.z} F${this.asyncPosition.v}`;
+    var cmd = `G0 X${this.asyncPosition.x} Y${this.asyncPosition.y} Z${this.asyncPosition.z} F${this.v}`;
     this.add(cmd);
 
     // prime the nozzle


### PR DESCRIPTION
I was running the `line_vase.js` example and added a printGCode function so that I could export it to a file. 

```
  printGcodeToConsole() {
    console.log("Printing all G-code:");
    this.commands.forEach((cmd, index) => {
      console.log(`${index + 1}: ${cmd}`);
    });
  }
  ```
  
  I noticed that after the `M83` command, the next feed rate value would be undefined.  When I checked the corresponding function, it referenced a property on `this.asyncPosition`, `v`, that was never set.  So I am assuming that `this.v` is what was originally intended, which is used in the rest of the functions.
  
## Before
<img width="631" alt="Screenshot 2024-05-06 at 1 55 06 PM" src="https://github.com/machineagency/p5.fab/assets/20407156/2fde06dd-e611-4def-89ef-1942fc1839b0">

## After
<img width="696" alt="Screenshot 2024-05-06 at 1 55 23 PM" src="https://github.com/machineagency/p5.fab/assets/20407156/1022b611-af6f-463e-832c-abf8f4dd8c49">

